### PR TITLE
Fix: Implement scroll to top on ingredient page load

### DIFF
--- a/src/hooks/useIngredientDetail.ts
+++ b/src/hooks/useIngredientDetail.ts
@@ -19,6 +19,15 @@ export const useIngredientDetail = () => {
   const { hasReachedLimit, recordPageView, getRemainingViews } = usePageViewLimit();
   const { toggleFavorite, isFavorite, loading: favoritesLoading } = useFavorites();
 
+  // Scroll automático al top cuando se carga un nuevo ingrediente
+  useEffect(() => {
+    if (ingredient?.id) {
+      // Usar 'instant' para móviles para evitar problemas de rendimiento
+      window.scrollTo({ top: 0, behavior: 'instant' });
+      console.log('🔝 Scroll automático al top para ingrediente:', ingredient.name);
+    }
+  }, [ingredient?.id]);
+
   // Redirect de URLs antiguas a URLs nuevas
   useEffect(() => {
     if (ingredient && isLegacyUrl && ingredient.slug) {


### PR DESCRIPTION
Implemented the plan to fix the mobile scroll issue by adding `window.scrollTo({ top: 0, behavior: 'instant' })` in `src/hooks/useIngredientDetail.ts` to ensure the page scrolls to the top when a new ingredient is loaded.