### PR TITLE
Fix: Address XML declaration error

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,5 @@
 
-# Servir sitemap.xml directamente con headers anti-cache
-/sitemap.xml    /sitemap.xml   200!  Cache-Control: no-cache,no-store,must-revalidate
+/sitemap.xml /sitemap.xml 200! Content-Type: application/xml Cache-Control: no-cache,no-store,must-revalidate
 
 # Redirección general para SPA
-/*    /index.html   200
+/* /index.html 200

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,52 +1,52 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://ingredientsindex.pro/</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/directorio</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/sobre-nosotros</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/contacto</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/categorias</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/privacidad</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/cookies</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
-  <url>
-    <loc>https://ingredientsindex.pro/terminos</loc>
-    <lastmod>2025-01-25T12:00:00.000Z</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.3</priority>
-  </url>
+<url>
+<loc>https://ingredientsindex.pro/</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>daily</changefreq>
+<priority>1.0</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/directorio</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>daily</changefreq>
+<priority>0.9</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/sobre-nosotros</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>monthly</changefreq>
+<priority>0.6</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/contacto</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>monthly</changefreq>
+<priority>0.5</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/categorias</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>weekly</changefreq>
+<priority>0.7</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/privacidad</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>yearly</changefreq>
+<priority>0.3</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/cookies</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>yearly</changefreq>
+<priority>0.3</priority>
+</url>
+<url>
+<loc>https://ingredientsindex.pro/terminos</loc>
+<lastmod>2025-01-25T12:00:00.000Z</lastmod>
+<changefreq>yearly</changefreq>
+<priority>0.3</priority>
+</url>
 </urlset>


### PR DESCRIPTION
Regenerate `public/sitemap.xml` and update `_redirects` with explicit `Content-Type` headers to ensure correct XML serving and prevent the "XML declaration allowed only at the start of the document" error.