### PR TITLE
feat: Implement AI Chef Pro banner

### DIFF
--- a/src/components/AIChefProBanner.tsx
+++ b/src/components/AIChefProBanner.tsx
@@ -1,0 +1,32 @@
+
+import { ExternalLink } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface AIChefProBannerProps {
+  className?: string;
+}
+
+const AIChefProBanner = ({ className = "" }: AIChefProBannerProps) => {
+  return (
+    <Card className={`bg-gradient-to-r from-blue-50 to-indigo-50 border-blue-200 hover:from-blue-100 hover:to-indigo-100 transition-all duration-300 ${className}`}>
+      <CardContent className="p-4">
+        <a
+          href="https://aichef.pro"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-start gap-3 text-decoration-none group"
+        >
+          <div className="text-2xl mt-0.5">🤖</div>
+          <div className="flex-1">
+            <div className="text-sm font-medium text-blue-900 group-hover:text-blue-700 transition-colors">
+              <span className="font-semibold">AI Chef Pro:</span> Prueba Gratis la Suite de Aplicaciones de Inteligencia Artificial para Chefs y profesionales de la hostelería aquí.
+            </div>
+          </div>
+          <ExternalLink className="h-4 w-4 text-blue-600 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+        </a>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AIChefProBanner;

--- a/src/components/ingredient-detail/IngredientMainCard.tsx
+++ b/src/components/ingredient-detail/IngredientMainCard.tsx
@@ -1,10 +1,11 @@
+
 import { Camera, TrendingUp, Zap, Sparkles, Heart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Ingredient } from "@/hooks/useIngredients";
 import StructuredDescription from "./StructuredDescription";
-import QualityValidator from "@/components/admin/QualityValidator";
+import AIChefProBanner from "@/components/AIChefProBanner";
 import { useSuperAdmin } from "@/hooks/useSuperAdmin";
 
 interface IngredientMainCardProps {
@@ -58,11 +59,10 @@ const IngredientMainCard = ({
   return (
     <Card className="bg-white/90">
       <CardContent className="p-6">
-        {isSuperAdmin && (
-          <div className="mb-4">
-            <QualityValidator ingredient={ingredient} />
-          </div>
-        )}
+        {/* AI Chef Pro Banner - visible for all users */}
+        <div className="mb-4">
+          <AIChefProBanner />
+        </div>
         
         <div className="flex flex-col md:flex-row gap-6">
           <div className="md:w-64 h-64 flex-shrink-0 relative">


### PR DESCRIPTION
Implement the plan to replace the super admin warning with a promotional banner for AI Chef Pro on ingredient detail pages. This includes creating the AIChefProBanner component, integrating it into IngredientMainCard.tsx, and ensuring it's visible to all users.