### PR TITLE
Implement Netlify redirects for social media meta tags

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,14 @@
 
 /sitemap.xml /sitemap.xml 200! Content-Type: application/xml Cache-Control: no-cache,no-store,must-revalidate
 
+# Redirección para bots sociales en URLs de ingredientes
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "facebookexternalhit*"}
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "Twitterbot*"}
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "WhatsApp*"}
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "TelegramBot*"}
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "LinkedInBot*"}
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "Slackbot*"}
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! headers={"User-Agent": "Discordbot*"}
+
 # Redirección general para SPA
 /* /index.html 200


### PR DESCRIPTION
Configure Netlify redirects to use the Edge Function for pre-rendering ingredient meta tags, ensuring correct social media sharing.