### PR TITLE
Fix: Make Edge Function public

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -93,3 +93,6 @@ verify_jwt = true
 
 [functions.test-connection]
 verify_jwt = true
+
+[functions.ingredient-meta-prerender]
+verify_jwt = false


### PR DESCRIPTION
Configure the Edge Function to be publicly accessible to resolve the 401 error, allowing social bots to access it without authentication.