### PR TITLE
Fix: Respect SPA in meta tag solution

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,8 +1,16 @@
 
 /sitemap.xml /sitemap.xml 200! Content-Type: application/xml Cache-Control: no-cache,no-store,must-revalidate
 
-# Proxy universal para ingredientes - manejará TODOS los casos en la Edge Function
-/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200
+# Solo interceptar bots sociales específicos para meta tags
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *facebookexternalhit*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *Twitterbot*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *WhatsApp*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *LinkedInBot*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *Slackbot*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *Discordbot*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *PostPlanner*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *Buffer*
+/ingrediente/* https://unqhfgupcutpeyepnavl.supabase.co/functions/v1/ingredient-meta-prerender/ingrediente/:splat 200! User-Agent: *Hootsuite*
 
 # Redirección general para SPA
 /* /index.html 200


### PR DESCRIPTION
Modify `_redirects` to only proxy specific social bots. Simplify the Edge Function to only generate meta tags for real bots, ensuring normal users go directly to the SPA. Use Netlify headers for bot detection.